### PR TITLE
build: pin github actions using hashes

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -7,8 +7,8 @@ jobs:
     name: Terraform format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.5
-      - uses: hashicorp/setup-terraform@v3.1.1
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           terraform_version: "~> 1.8.0"
           # no need for the wrapper


### PR DESCRIPTION
Prevent tampering by using hashes to pin GitHub Action versions. Add tag as a comment. Both will be updated by Dependabot.