### PR TITLE
feat: improve github_branch_protection

### DIFF
--- a/repos.tf
+++ b/repos.tf
@@ -28,6 +28,8 @@ variable "branch_protections" {
   type = list(object({
     name                            = string
     enforce_admins                  = optional(bool, true)
+    allows_deletions                = optional(bool, false)
+    allows_force_pushes             = optional(bool, false)
     required_linear_history         = optional(bool, true)
     strict                          = optional(bool, true)
     contexts                        = optional(list(string), [])
@@ -80,11 +82,16 @@ resource "github_branch_protection" "this" {
   repository_id           = github_repository.this[each.value.name].node_id
   pattern                 = github_repository.this[each.value.name].default_branch
   enforce_admins          = each.value.enforce_admins
+  allows_deletions        = each.value.allows_deletions
+  allows_force_pushes     = each.value.allows_force_pushes
   required_linear_history = each.value.required_linear_history
+
   required_status_checks {
+    # this is only honoured if there is a GitHub status check (a context)
     strict   = each.value.strict
     contexts = each.value.contexts
   }
+
   required_pull_request_reviews {
     required_approving_review_count = each.value.required_approving_review_count
     require_last_push_approval      = each.value.require_last_push_approval


### PR DESCRIPTION
Make `allows_deletions` and `allows_force_pushes` explicit.

Clarify that `strict` only works if there are status checks that are run.