### PR TITLE
build: make no-fixups mandatory

### DIFF
--- a/branch_protections.auto.tfvars
+++ b/branch_protections.auto.tfvars
@@ -4,6 +4,7 @@ branch_protections = [
     contexts = [
       "Terraform format check",
       "Terraform Cloud/matijs/repo-id-xTdtApDiyNBVUu6g",
+      "no-fixups",
     ]
   },
   {


### PR DESCRIPTION
Add "no-fixups" to the branch_protection of the main branch of the github-terraform repo