### PR TITLE
refactor: set GITHUB_TOKEN using Terraform var

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -14,3 +14,7 @@ terraform {
     }
   }
 }
+
+provider "github" {
+  token = var.GITHUB_TOKEN
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,6 @@
+variable "GITHUB_TOKEN" {
+  description = "GitHub personal access token"
+  type        = string
+  sensitive   = true
+}
+


### PR DESCRIPTION
Use a Terraform input variable to provide GITHUB_TOKEN instead of relying on an environment variable.