### PR TITLE
chore: bump terraform required_version

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.9.0"
+  required_version = "~> 1.10.0"
 
   cloud {
     organization = "matijs"


### PR DESCRIPTION
Bump version from ~1.9.0 to ~1.10.0