### PR TITLE
refactor: turn off legacy branch protection

### DIFF
--- a/branch_protections.auto.tfvars
+++ b/branch_protections.auto.tfvars
@@ -19,8 +19,5 @@ branch_protections = [
     contexts = [
       "no-fixups",
     ]
-  },
-  {
-    name = "til"
   }
 ]

--- a/branch_rulesets.auto.tfvars
+++ b/branch_rulesets.auto.tfvars
@@ -1,6 +1,7 @@
 branch_rulesets = [
   {
-    name       = "main"
-    repository = "til"
+    enforcement         = "active"
+    repository          = "til"
+    required_signatures = true
   }
 ]

--- a/repos.tf
+++ b/repos.tf
@@ -43,6 +43,7 @@ variable "branch_rulesets" {
     name                            = optional(string, "main-branch-protection")
     repository                      = string
     enforcement                     = optional(string, "disabled")
+    required_signatures             = optional(bool, false)
     required_linear_history         = optional(bool, true)
     required_approving_review_count = optional(number, 0)
     require_last_push_approval      = optional(bool, false)
@@ -108,6 +109,7 @@ resource "github_repository_ruleset" "branch_protection" {
       require_last_push_approval      = each.value.require_last_push_approval
     }
     required_linear_history = each.value.required_linear_history
+    required_signatures     = each.value.required_signatures
   }
 }
 


### PR DESCRIPTION
For the "til" repo, turn of legacy branch protection and switch to the new ruleset