### PR TITLE
refactor: turn off legacy branch protection

### DIFF
--- a/branch_rulesets.auto.tfvars
+++ b/branch_rulesets.auto.tfvars
@@ -1,7 +1,12 @@
 branch_rulesets = [
   {
-    enforcement         = "active"
+    repository          = "github-terraform"
+    enforcement         = "disabled"
+    required_signatures = true
+  },
+  {
     repository          = "til"
+    enforcement         = "active"
     required_signatures = true
   }
 ]


### PR DESCRIPTION
For the "github-terraform" repo, turn of legacy branch protection and switch to the new ruleset