### PR TITLE
fix: remove github_repository_ruleset

### DIFF
--- a/github_repository_ruleset.tf
+++ b/github_repository_ruleset.tf
@@ -1,9 +1,0 @@
-resource "github_repository_ruleset" "require-linear-history" {
-  enforcement = "active"
-  name        = "require-linear-history"
-  target      = "branch"
-
-  rules {
-    required_linear_history = true
-  }
-}


### PR DESCRIPTION
It seems "repository" is not optional at all so this failed.