### PR TITLE
refactor: rename rulesets

### DIFF
--- a/branch_rulesets.auto.tfvars
+++ b/branch_rulesets.auto.tfvars
@@ -1,6 +1,0 @@
-branch_rulesets = {
-  "til" = {
-    enforcement         = "active"
-    required_signatures = true
-  }
-}

--- a/repositories.tf
+++ b/repositories.tf
@@ -50,31 +50,6 @@ resource "github_repository" "repository" {
   }
 }
 
-resource "github_repository_ruleset" "branch_protection" {
-  for_each = var.branch_rulesets
-
-  enforcement = each.value.enforcement
-  name        = each.value.name
-  repository  = each.key
-  target      = "branch"
-
-  conditions {
-    ref_name {
-      include = ["refs/heads/main"]
-      exclude = []
-    }
-  }
-
-  rules {
-    pull_request {
-      required_approving_review_count = each.value.required_approving_review_count
-      require_last_push_approval      = each.value.require_last_push_approval
-    }
-    required_linear_history = each.value.required_linear_history
-    required_signatures     = each.value.required_signatures
-  }
-}
-
 resource "github_branch_protection" "b" {
   for_each = { for p in var.branch_protections : p.name => p }
 

--- a/rulesets.auto.tfvars
+++ b/rulesets.auto.tfvars
@@ -1,0 +1,5 @@
+rulesets = {
+  "til" = {
+    required_signatures = true
+  }
+}

--- a/rulesets.tf
+++ b/rulesets.tf
@@ -1,0 +1,26 @@
+resource "github_repository_ruleset" "ruleset" {
+  for_each = var.rulesets
+
+  enforcement = each.value.enforcement
+  name        = each.value.name
+  repository  = each.key
+  target      = "branch"
+
+  conditions {
+    ref_name {
+      include = ["refs/heads/main"]
+      exclude = []
+    }
+  }
+
+  rules {
+    pull_request {
+      required_approving_review_count = each.value.required_approving_review_count
+      require_last_push_approval      = each.value.require_last_push_approval
+    }
+    required_linear_history = each.value.required_linear_history
+    required_signatures     = each.value.required_signatures
+  }
+}
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -29,10 +29,10 @@ variable "repositories" {
   }))
 }
 
-variable "branch_rulesets" {
+variable "rulesets" {
   type = map(object({
     name                            = optional(string, "main-branch-protection")
-    enforcement                     = optional(string, "disabled")
+    enforcement                     = optional(string, "active")
     required_signatures             = optional(bool, false)
     required_linear_history         = optional(bool, true)
     required_approving_review_count = optional(number, 0)


### PR DESCRIPTION
- Rename branch_rulesets to just rulesets
- Rename the github_repository_ruleset from "branch_protection" to just "ruleset"
- Move github_repository_ruleset to rulesets.tf