### PR TITLE
feat: protect the default branch

### DIFF
--- a/rulesets.tf
+++ b/rulesets.tf
@@ -8,7 +8,7 @@ resource "github_repository_ruleset" "ruleset" {
 
   conditions {
     ref_name {
-      include = ["refs/heads/main"]
+      include = ["~DEFAULT_BRANCH"]
       exclude = []
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "repositories" {
 variable "rulesets" {
   type = map(object({
     enforcement = optional(string, "active")
-    name        = optional(string, "main-branch-protection")
+    name        = optional(string, "default-branch-protection")
 
     rules = object({
       non_fast_forward              = optional(bool, true)


### PR DESCRIPTION
Instead of using "refs/heads/main", use "~DEFAULT_BRANCH" to protect the main branch.