### PR TITLE
feat: improve repositoy rulesets

### DIFF
--- a/rulesets.tf
+++ b/rulesets.tf
@@ -14,6 +14,7 @@ resource "github_repository_ruleset" "ruleset" {
   }
 
   rules {
+    creation                = each.value.rules.creation
     deletion                = each.value.rules.deletion
     non_fast_forward        = each.value.rules.non_fast_forward
     required_linear_history = each.value.rules.required_linear_history

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,7 @@ variable "rulesets" {
     name        = optional(string, "default-branch-protection")
 
     rules = object({
+      creation                      = optional(bool, true)
       deletion                      = optional(bool, true)
       non_fast_forward              = optional(bool, true)
       required_linear_history       = optional(bool, true)


### PR DESCRIPTION
Default to restricting creatations of the ref. In this instance (`~DEFAULT_BRANCH`) this would kind of make sense because the branch already exists.