### PR TITLE
chore: simplify CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 * @matijs
-.* @matijs


### PR DESCRIPTION
`*` is enough to also own dotfiles apparently