### PR TITLE
chore: tighten ruleset

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -44,8 +44,8 @@ variable "rulesets" {
       update_allows_fetch_and_merge = optional(bool, false)
 
       pull_request = optional(object({
-        dismiss_stale_reviews_on_push     = optional(bool, false)
-        require_code_owner_review         = optional(bool, false)
+        dismiss_stale_reviews_on_push     = optional(bool, true)
+        require_code_owner_review         = optional(bool, true)
         require_last_push_approval        = optional(bool, false)
         required_approving_review_count   = optional(number, 0)
         required_review_thread_resolution = optional(bool, false)


### PR DESCRIPTION
Default to `true` for dismiss_stale_reviews_on_push which would dismiss approvals for for example dependabot PRs.

Default to `true` for require_code_owner_review which should be safe if there is no CODEOWNERS file.