### PR TITLE
chore: remove CodeQL

### DIFF
--- a/rulesets.auto.tfvars
+++ b/rulesets.auto.tfvars
@@ -25,10 +25,6 @@ rulesets = {
             context        = "no-fixups"
             integration_id = 15368
           },
-          {
-            context        = "CodeQL"
-            integration_id = 57789
-          },
         ]
       }
     }


### PR DESCRIPTION
The github-terraform repo does not have CodeQL set up because it can't so don't require it as a test.